### PR TITLE
fix: correct dimensions for setRotation into wide format and back

### DIFF
--- a/lib-st7735/src/ST7735_TFT.c
+++ b/lib-st7735/src/ST7735_TFT.c
@@ -703,21 +703,29 @@ void setRotation(uint8_t m) {
   switch (_rotation) {
   case 0:
     madctl = ST7735_MADCTL_MX | ST7735_MADCTL_MY | ST7735_MADCTL_RGB;
+    _height = 160;
+    _width = 128;
     _xstart = _colstart;
     _ystart = _rowstart;
     break;
   case 1:
     madctl = ST7735_MADCTL_MY | ST7735_MADCTL_MV | ST7735_MADCTL_RGB;
+    _width = 160;
+    _height = 128;
     _ystart = _colstart;
     _xstart = _rowstart;
     break;
   case 2:
     madctl = ST7735_MADCTL_RGB;
+    _height = 160;
+    _width = 128;
     _xstart = _colstart;
     _ystart = _rowstart;
     break;
   case 3:
     madctl = ST7735_MADCTL_MX | ST7735_MADCTL_MV | ST7735_MADCTL_RGB;
+    _width = 160;
+    _height = 128;
     _ystart = _colstart;
     _xstart = _rowstart;
     break;


### PR DESCRIPTION
See also https://github.com/bablokb/pico-st7735/issues/5

Here's the difference with the latest Test10 (which I PR'd to your demo repo)

| before | after |
| ---- | ---- |
|<img src="https://github.com/user-attachments/assets/de7bca83-a57c-47be-a24a-b8128e625fea" width="200" > | <img src="https://github.com/user-attachments/assets/207e8f03-13eb-4e64-ac70-4edfc8d5a6c0" width="200" > |
| <img src="https://github.com/user-attachments/assets/1320def7-cd4d-428a-8353-bfbe5d80e542" width="200" > | <img src="https://github.com/user-attachments/assets/0447fc66-3214-432b-a62b-72eac32f80a8" width="200" > |
| <img src="https://github.com/user-attachments/assets/8f0d44f9-9029-4cc5-a730-3da5d0f5a146" width="200" > | <img src="https://github.com/user-attachments/assets/cec23844-ada6-4fc3-a4f5-1aa9545a5639" width="200" >|
| <img src="https://github.com/user-attachments/assets/440dfeb8-bb11-4e36-9c75-6ec367269d3e" width="200" > | <img src="https://github.com/user-attachments/assets/6d2bbd48-0fac-44a2-8dd1-dbca1328d04f" width="200" > |
